### PR TITLE
Ask curl to follow redirects

### DIFF
--- a/install
+++ b/install
@@ -38,7 +38,7 @@
   { have nix-shell && ! have nix; } && {
     echo >&2 "You seem to be running a Nix version lower than 2.0"
     echo >&2 "Please upgrade to Nix v2 before running this script"
-    echo >&2 "You can run \`curl -sS https://nixos.org/nix/install | sh\`"
+    echo >&2 "You can run \`curl -sSL https://nixos.org/nix/install | sh\`"
     exit 1
   }
 
@@ -49,7 +49,7 @@
     echo "Dapptools uses the Nix package manager to install programs behind the scenes."
     echo "Installing Nix in single-user mode, you may be asked for your sudo password."
 
-    curl -sS https://nixos.org/nix/install | sh
+    curl -sSL https://nixos.org/nix/install | sh
 
     # shellcheck source=/dev/null
     . "$HOME/.nix-profile/etc/profile.d/nix.sh"


### PR DESCRIPTION
Looks like `nixos` have added a redirect to their nix install URL (note the `301`):

```$ curl -LI https://nixos.org/nix/install
HTTP/2 301 
content-length: 0
date: Tue, 30 Jun 2020 05:22:14 GMT
location: https://releases.nixos.org/nix/nix-2.3.6/install
server: Netlify
via: 1.1 fd2442d18add87f1fea3351cec311828.cloudfront.net (CloudFront)
x-amz-cf-id: DQ4pW9nGdDmQmVzfFnK0FDRw4KsNs9ki8Txx3Fy4CFnZSEFYt9zcbw==
x-amz-cf-pop: SYD1-C1
x-cache: Miss from cloudfront
age: 649
x-nf-request-id: 60178b8c-fc87-4c4b-bd07-8988de9558f9-10561528

HTTP/2 200 
content-type: binary/octet-stream
content-length: 2490
last-modified: Wed, 03 Jun 2020 12:57:25 GMT
accept-ranges: bytes
server: AmazonS3
date: Tue, 30 Jun 2020 04:05:44 GMT
etag: "8cecc3ad30be6cb781c8901f3e66b129"
x-cache: Hit from cloudfront
via: 1.1 1369caa4af860e01f6742e6db0fb9ed1.cloudfront.net (CloudFront)
x-amz-cf-pop: SYD1-C2
x-amz-cf-id: 67g9pRjo1lRomCPxsXZCjFs9klStnOFfvsWi8T61fRDrG9E4qCO9wg==
age: 5238
```

By default `curl` doesn't follow redirects so right now the `curl` command just returns blank and the install continues but fails with failing to source `nix.sh`

Adding flag to follow redirects.